### PR TITLE
CDM-23 Externalize the db password

### DIFF
--- a/demo-app/src/main/resources/application.yml
+++ b/demo-app/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     url: jdbc:h2:mem:mydb
     username: sa
-    password: password
+    password: ${DB_PASSWORD}
     driverClassName: org.h2.Driver
   jpa:
     spring.jpa.database-platform: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
# About
This change set is externalizing the db password so that it does not get hosted in plain text in version control
# Testing
Configured a dummy password in the env variables and tested the connection
![image](https://github.com/CatalinM89/client-data-management/assets/157151214/3431a080-2d82-4b3a-bc98-9c7fad3f7253)
![image](https://github.com/CatalinM89/client-data-management/assets/157151214/9aa6187b-3062-4d6a-87c5-e2a47beaddf3)
![image](https://github.com/CatalinM89/client-data-management/assets/157151214/1bef5d10-5b15-4bbf-8711-12b78a6a5b45)

